### PR TITLE
Include default credentials in WebUI readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,3 +25,10 @@ cp -R build ../public
 # (In directory: ~/free5gc/webconsole)
 go run server.go
 ```
+
+### Connect to WebConsole
+
+Enter <WebConsole server's IP>:5000 in URL bar.
+
+Username: admin
+Password: free5gc


### PR DESCRIPTION
Hi,

The default credentials are referenced in the wiki here https://github.com/free5gc/free5gc/wiki/New-Subscriber-via-webconsole but I find it appropriate to have them also included in the WebUI readme file.

Cheers,