### PR TITLE
Fix: MSISDN -> GPSI

### DIFF
--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -159,7 +159,7 @@ func setCorsHeader(c *gin.Context) {
 	c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, PATCH, DELETE")
 }
 
-func getMsisdn(gpsis interface{}) string {
+func getMsisdn(gpsis interface{}) string { // select first msisdn from gpsis
 	msisdn := ""
 	gpsisReflected := reflect.ValueOf(gpsis) // use reflect to range over interface{}
 	for i := 0; i < gpsisReflected.Len(); i++ {
@@ -171,22 +171,22 @@ func getMsisdn(gpsis interface{}) string {
 	return msisdn
 }
 
-func gpsiToSupi(ueId string) string {
-	if strings.HasPrefix(ueId, "msisdn-") {
-		filter := bson.M{"msisdn": ueId[7:]}
+func gpsiToSupi(gpsi string) string {
+	if strings.HasPrefix(gpsi, "msisdn-") { // if gpsi's prefix is "msisdn-"
+		filter := bson.M{"gpsi": gpsi[7:]}
 		dbResult, err := mongoapi.RestfulAPIGetOne(identityDataColl, filter)
 		if err != nil {
 			logger.ProcLog.Errorf("GetSupibyMsisdn err: %+v", err)
 		}
 		if dbResult != nil {
-			ueId = dbResult["ueId"].(string)
+			gpsi = dbResult["ueId"].(string)
 		} else {
 			// db cannot find a supi mapped to msisdn, return null string for error detection
 			logger.ProcLog.Error("msisdn not found")
 			return ""
 		}
 	}
-	return ueId
+	return gpsi
 }
 
 func sendResponseToClient(c *gin.Context, response *http.Response) {
@@ -1028,7 +1028,7 @@ func GetSubscribers(c *gin.Context) {
 	for _, amData := range amDataList {
 		ueId := amData["ueId"]
 		servingPlmnId := amData["servingPlmnId"]
-		msisdn := getMsisdn(amData["gpsis"])
+		gpsi := getMsisdn(amData["gpsis"])
 		tenantId := amData["tenantId"]
 
 		filterUeIdOnly := bson.M{"ueId": ueId}
@@ -1051,7 +1051,7 @@ func GetSubscribers(c *gin.Context) {
 			tmp := SubsListIE{
 				PlmnID: servingPlmnId.(string),
 				UeId:   ueId.(string),
-				Msisdn: msisdn,
+				Gpsi:   gpsi,
 			}
 			subsList = append(subsList, tmp)
 		}
@@ -1070,11 +1070,11 @@ func GetSubscriberByID(c *gin.Context) {
 	ueId := c.Param("ueId")
 	ueId = gpsiToSupi(ueId)
 	servingPlmnId := c.Param("servingPlmnId")
-	// checking whether msisdn is successfully transformed to supi or not
+	// checking whether gpsi is successfully transformed to supi or not
 	if ueId == "" {
-		logger.ProcLog.Errorf("GetSubscriberByID err: msisdn does not exists")
+		logger.ProcLog.Errorf("GetSubscriberByID err: gpsi does not exists")
 		c.JSON(http.StatusNotFound, gin.H{
-			"cause": "msisdn does not exists",
+			"cause": "gpsi does not exists",
 		})
 		return
 	}
@@ -1261,14 +1261,14 @@ func PostSubscriberByID(c *gin.Context) {
 		})
 		return
 	}
-	msisdn := getMsisdn(toBsonM(subsData.AccessAndMobilitySubscriptionData)["gpsis"])
-	msisdnTemp := 0
-	if msisdn != "" {
-		msisdnTemp, err = strconv.Atoi(msisdn)
+	gpsi := getMsisdn(toBsonM(subsData.AccessAndMobilitySubscriptionData)["gpsis"])
+	gpsiTemp := 0
+	if gpsi != "" {
+		gpsiTemp, err = strconv.Atoi(gpsi)
 		if err != nil {
 			logger.ProcLog.Errorf("PostSubscriberByID err: %+v", err)
 			c.JSON(http.StatusBadRequest, gin.H{
-				"cause": "msisdn format incorrect",
+				"cause": "gpsi format incorrect",
 			})
 			return
 		}
@@ -1285,22 +1285,22 @@ func PostSubscriberByID(c *gin.Context) {
 
 	for i := 0; i < userNumberTemp; i++ {
 		ueId = fmt.Sprintf("imsi-%015d", ueIdTemp)
-		if msisdnTemp != 0 {
-			if !validate(ueId, msisdn) {
-				logger.ProcLog.Errorf("duplicate msisdn: %v", msisdn)
+		if gpsiTemp != 0 {
+			if !validate(ueId, gpsi) {
+				logger.ProcLog.Errorf("duplicate gpsi: %v", gpsi)
 				c.JSON(http.StatusBadRequest, gin.H{
-					"cause": "duplicate msisdn",
+					"cause": "duplicate gpsi",
 				})
 				return
 			}
-			msisdnTemp += 1
+			gpsiTemp += 1
 		}
 		ueIdTemp += 1
 
-		subsData.AccessAndMobilitySubscriptionData.Gpsis[0] = "msisdn-" + msisdn
+		subsData.AccessAndMobilitySubscriptionData.Gpsis[0] = "msisdn-" + gpsi
 		// create a msisdn-supi map
-		logger.ProcLog.Infof("PostSubscriberByID msisdn: %+v", msisdn)
-		identityDataOperation(ueId, msisdn, "post")
+		logger.ProcLog.Infof("PostSubscriberByID gpsi: %+v", subsData.AccessAndMobilitySubscriptionData.Gpsis[0])
+		identityDataOperation(ueId, gpsi, "post")
 		filterUeIdOnly := bson.M{"ueId": ueId}
 
 		// Lookup same UE ID of other tenant's subscription.
@@ -1323,25 +1323,25 @@ func PostSubscriberByID(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{})
 }
 
-func validate(supi string, msisdn string) bool {
-	filter := bson.M{"msisdn": msisdn}
-	msisdnSupiMap, err := mongoapi.RestfulAPIGetOne(identityDataColl, filter)
+func validate(supi string, gpsi string) bool {
+	filter := bson.M{"gpsi": gpsi}
+	identityData, err := mongoapi.RestfulAPIGetOne(identityDataColl, filter)
 	if err != nil {
 		logger.ProcLog.Errorf("GetSubscriberByID err: %+v", err)
 	}
-	if msisdnSupiMap != nil && msisdnSupiMap["ueId"] != supi {
+	if identityData != nil && identityData["ueId"] != supi {
 		return false
 	} else {
 		return true
 	}
 }
 
-func identityDataOperation(supi string, msisdn string, method string) {
+func identityDataOperation(supi string, gpsi string, method string) {
 	filter := bson.M{"ueId": supi}
-	data := bson.M{"ueId": supi, "msisdn": msisdn}
+	data := bson.M{"ueId": supi, "gpsi": gpsi}
 
 	if method == "put" || method == "post" {
-		if msisdn != "" {
+		if gpsi != "" {
 			if _, err := mongoapi.RestfulAPIPutOne(identityDataColl, filter, data); err != nil {
 				logger.ProcLog.Errorf("PutIdentityData err: %+v", err)
 			}
@@ -1392,7 +1392,7 @@ func dbOperation(ueId string, servingPlmnId string, method string, subsData *Sub
 			logger.ProcLog.Errorf("DeleteSubscriberByID err: %+v", err)
 		}
 		if err := mongoapi.RestfulAPIDeleteOne(identityDataColl, filterUeIdOnly); err != nil {
-			logger.ProcLog.Errorf("DeleteMsisdnSupiMap err: %+v", err)
+			logger.ProcLog.Errorf("DeleteIdnetityData err: %+v", err)
 		}
 	}
 	if method == "post" || method == "put" {
@@ -1502,18 +1502,18 @@ func PutSubscriberByID(c *gin.Context) {
 	}
 	ueId := c.Param("ueId")
 	servingPlmnId := c.Param("servingPlmnId")
-	// modify a msisdn-supi map
-	msisdn := getMsisdn(toBsonM(subsData.AccessAndMobilitySubscriptionData)["gpsis"])
-	if !validate(ueId, msisdn) {
-		logger.ProcLog.Errorf("duplicate msisdn: %v", msisdn)
+	// modify a gpsi-supi map
+	gpsi := getMsisdn(toBsonM(subsData.AccessAndMobilitySubscriptionData)["gpsis"])
+	if !validate(ueId, gpsi) {
+		logger.ProcLog.Errorf("duplicate gpsi: %v", gpsi)
 		c.JSON(http.StatusBadRequest, gin.H{
-			"cause": "duplicate msisdn",
+			"cause": "duplicate gpsi",
 		})
 		return
 	}
 
-	logger.ProcLog.Infof("PutSubscriberByID msisdn: %+v", msisdn)
-	identityDataOperation(ueId, msisdn, "put")
+	logger.ProcLog.Infof("PutSubscriberByID gpsi: %+v", gpsi)
+	identityDataOperation(ueId, gpsi, "put")
 
 	var claims jwt.MapClaims = nil
 	dbOperation(ueId, servingPlmnId, "put", &subsData, claims)
@@ -1535,23 +1535,23 @@ func PatchSubscriberByID(c *gin.Context) {
 	}
 
 	ueId := c.Param("ueId")
-	ueId = gpsiToSupi(ueId)
+	supi := gpsiToSupi(ueId)
 	servingPlmnId := c.Param("servingPlmnId")
-	// checking whether msisdn is successfully transformed to supi or not
+	// checking whether gpsi is successfully transformed to supi or not
 	if ueId == "" {
-		logger.ProcLog.Errorf("PatchSubscriberByID err: msisdn does not exists")
+		logger.ProcLog.Errorf("PatchSubscriberByID err: gpsi does not exists")
 		c.JSON(http.StatusNotFound, gin.H{
-			"cause": "msisdn does not exists",
+			"cause": "gpsi does not exists",
 		})
 		return
 	}
-	filterUeIdOnly := bson.M{"ueId": ueId}
-	filter := bson.M{"ueId": ueId, "servingPlmnId": servingPlmnId}
+	filterUeIdOnly := bson.M{"ueId": supi}
+	filter := bson.M{"ueId": supi, "servingPlmnId": servingPlmnId}
 
 	authSubsBsonM := toBsonM(subsData.AuthenticationSubscription)
-	authSubsBsonM["ueId"] = ueId
+	authSubsBsonM["ueId"] = supi
 	amDataBsonM := toBsonM(subsData.AccessAndMobilitySubscriptionData)
-	amDataBsonM["ueId"] = ueId
+	amDataBsonM["ueId"] = supi
 	amDataBsonM["servingPlmnId"] = servingPlmnId
 
 	// Replace all data with new one
@@ -1562,9 +1562,9 @@ func PatchSubscriberByID(c *gin.Context) {
 	}
 	for _, data := range subsData.SessionManagementSubscriptionData {
 		smDataBsonM := toBsonM(data)
-		smDataBsonM["ueId"] = ueId
+		smDataBsonM["ueId"] = supi
 		smDataBsonM["servingPlmnId"] = servingPlmnId
-		filterSmData := bson.M{"ueId": ueId, "servingPlmnId": servingPlmnId, "snssai": data.SingleNssai}
+		filterSmData := bson.M{"ueId": supi, "servingPlmnId": servingPlmnId, "snssai": data.SingleNssai}
 		if err := mongoapi.RestfulAPIMergePatch(smDataColl, filterSmData, smDataBsonM); err != nil {
 			logger.ProcLog.Errorf("PatchSubscriberByID err: %+v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{})
@@ -1573,12 +1573,12 @@ func PatchSubscriberByID(c *gin.Context) {
 	}
 
 	smfSelSubsBsonM := toBsonM(subsData.SmfSelectionSubscriptionData)
-	smfSelSubsBsonM["ueId"] = ueId
+	smfSelSubsBsonM["ueId"] = supi
 	smfSelSubsBsonM["servingPlmnId"] = servingPlmnId
 	amPolicyDataBsonM := toBsonM(subsData.AmPolicyData)
-	amPolicyDataBsonM["ueId"] = ueId
+	amPolicyDataBsonM["ueId"] = supi
 	smPolicyDataBsonM := toBsonM(subsData.SmPolicyData)
-	smPolicyDataBsonM["ueId"] = ueId
+	smPolicyDataBsonM["ueId"] = supi
 
 	if err := mongoapi.RestfulAPIMergePatch(authSubsDataColl, filterUeIdOnly, authSubsBsonM); err != nil {
 		logger.ProcLog.Errorf("PatchSubscriberByID err: %+v", err)
@@ -1614,18 +1614,18 @@ func DeleteSubscriberByID(c *gin.Context) {
 	setCorsHeader(c)
 	logger.ProcLog.Infoln("Delete One Subscriber Data")
 	ueId := c.Param("ueId")
-	ueId = gpsiToSupi(ueId)
+	supi := gpsiToSupi(ueId)
 	servingPlmnId := c.Param("servingPlmnId")
-	// checking whether msisdn is successfully transformed to supi or not
-	if ueId == "" {
-		logger.ProcLog.Errorf("DeleteSubscriberByID err: msisdn does not exists")
+	// checking whether supi is successfully transformed to supi or not
+	if supi == "" {
+		logger.ProcLog.Errorf("DeleteSubscriberByID err: supi does not exists")
 		c.JSON(http.StatusNotFound, gin.H{
-			"cause": "msisdn does not exists",
+			"cause": "supi does not exists",
 		})
 		return
 	}
 	var claims jwt.MapClaims = nil
-	dbOperation(ueId, servingPlmnId, "delete", nil, claims)
+	dbOperation(supi, servingPlmnId, "delete", nil, claims)
 	c.JSON(http.StatusNoContent, gin.H{})
 }
 

--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -26,17 +26,17 @@ import (
 )
 
 const (
-	authSubsDataColl  = "subscriptionData.authenticationData.authenticationSubscription"
-	amDataColl        = "subscriptionData.provisionedData.amData"
-	smDataColl        = "subscriptionData.provisionedData.smData"
-	smfSelDataColl    = "subscriptionData.provisionedData.smfSelectionSubscriptionData"
-	amPolicyDataColl  = "policyData.ues.amData"
-	smPolicyDataColl  = "policyData.ues.smData"
-	flowRuleDataColl  = "policyData.ues.flowRule"
-	qosFlowDataColl   = "policyData.ues.qosFlow"
-	userDataColl      = "userData"
-	tenantDataColl    = "tenantData"
-	msisdnSupiMapColl = "subscriptionData.msisdnSupiMap"
+	authSubsDataColl = "subscriptionData.authenticationData.authenticationSubscription"
+	amDataColl       = "subscriptionData.provisionedData.amData"
+	smDataColl       = "subscriptionData.provisionedData.smData"
+	smfSelDataColl   = "subscriptionData.provisionedData.smfSelectionSubscriptionData"
+	amPolicyDataColl = "policyData.ues.amData"
+	smPolicyDataColl = "policyData.ues.smData"
+	flowRuleDataColl = "policyData.ues.flowRule"
+	qosFlowDataColl  = "policyData.ues.qosFlow"
+	userDataColl     = "userData"
+	tenantDataColl   = "tenantData"
+	identityDataColl = "subscriptionData.identityData"
 )
 
 var jwtKey = "" // for generating JWT
@@ -174,7 +174,7 @@ func getMsisdn(gpsis interface{}) string {
 func msisdnToSupi(ueId string) string {
 	if strings.HasPrefix(ueId, "msisdn-") {
 		filter := bson.M{"msisdn": ueId[7:]}
-		dbResult, err := mongoapi.RestfulAPIGetOne(msisdnSupiMapColl, filter)
+		dbResult, err := mongoapi.RestfulAPIGetOne(identityDataColl, filter)
 		if err != nil {
 			logger.ProcLog.Errorf("GetSupibyMsisdn err: %+v", err)
 		}
@@ -1325,7 +1325,7 @@ func PostSubscriberByID(c *gin.Context) {
 
 func validate(supi string, msisdn string) bool {
 	filter := bson.M{"msisdn": msisdn}
-	msisdnSupiMap, err := mongoapi.RestfulAPIGetOne(msisdnSupiMapColl, filter)
+	msisdnSupiMap, err := mongoapi.RestfulAPIGetOne(identityDataColl, filter)
 	if err != nil {
 		logger.ProcLog.Errorf("GetSubscriberByID err: %+v", err)
 	}
@@ -1342,12 +1342,12 @@ func msisdnSupiMapOperation(supi string, msisdn string, method string) {
 
 	if method == "put" || method == "post" {
 		if msisdn != "" {
-			if _, err := mongoapi.RestfulAPIPutOne(msisdnSupiMapColl, filter, data); err != nil {
+			if _, err := mongoapi.RestfulAPIPutOne(identityDataColl, filter, data); err != nil {
 				logger.ProcLog.Errorf("PutMsisdnSupiMap err: %+v", err)
 			}
 		} else {
 			// delete
-			if err := mongoapi.RestfulAPIDeleteOne(msisdnSupiMapColl, filter); err != nil {
+			if err := mongoapi.RestfulAPIDeleteOne(identityDataColl, filter); err != nil {
 				logger.ProcLog.Errorf("DeleteMsisdnSupiMap err: %+v", err)
 			}
 		}
@@ -1391,7 +1391,7 @@ func dbOperation(ueId string, servingPlmnId string, method string, subsData *Sub
 		if err := mongoapi.RestfulAPIDeleteMany(qosFlowDataColl, filter); err != nil {
 			logger.ProcLog.Errorf("DeleteSubscriberByID err: %+v", err)
 		}
-		if err := mongoapi.RestfulAPIDeleteOne(msisdnSupiMapColl, filterUeIdOnly); err != nil {
+		if err := mongoapi.RestfulAPIDeleteOne(identityDataColl, filterUeIdOnly); err != nil {
 			logger.ProcLog.Errorf("DeleteMsisdnSupiMap err: %+v", err)
 		}
 	}

--- a/backend/WebUI/model_subs_list_ie.go
+++ b/backend/WebUI/model_subs_list_ie.go
@@ -3,5 +3,5 @@ package WebUI
 type SubsListIE struct {
 	PlmnID string `json:"plmnID"`
 	UeId   string `json:"ueId"`
-	Msisdn string `json:"msisdn"`
+	Gpsi   string `json:"gpsi"`
 }

--- a/frontend/src/pages/SubscriberCreate.tsx
+++ b/frontend/src/pages/SubscriberCreate.tsx
@@ -1256,7 +1256,7 @@ export default function SubscriberCreate() {
             <TableRow>
               <TableCell>
                 <TextField
-                  label="MSISDN"
+                  label="GPSI (MSISDN)"
                   variant="outlined"
                   required
                   fullWidth

--- a/frontend/src/pages/SubscriberRead.tsx
+++ b/frontend/src/pages/SubscriberRead.tsx
@@ -76,7 +76,7 @@ export default function SubscriberRead() {
       return "";
     } else {
       if (subData.gpsis !== undefined && subData.gpsis!.length !== 0) {
-        return subData.gpsis[0].replace("msisdn-", "");
+        return subData.gpsis[0].replaceAll("msisdn-", "");
       } else {
         return "";
       }
@@ -243,7 +243,7 @@ export default function SubscriberRead() {
           </TableBody>
           <TableBody>
             <TableRow>
-              <TableCell style={{ width: "40%" }}>MSISDN</TableCell>
+              <TableCell style={{ width: "40%" }}>GPSI (MSISDN)</TableCell>
               <TableCell>{msisdnValue(data.AccessAndMobilitySubscriptionData)}</TableCell>
             </TableRow>
           </TableBody>

--- a/frontend/src/pages/SubscriberUpdate.tsx
+++ b/frontend/src/pages/SubscriberUpdate.tsx
@@ -271,7 +271,7 @@ export default function SubscriberUpdate() {
       return "";
     } else {
       if (subData.gpsis !== undefined && subData.gpsis!.length !== 0) {
-        return subData.gpsis[0].replace("msisdn-", "");
+        return subData.gpsis[0].replaceAll("msisdn-", "");
       } else {
         return "";
       }


### PR DESCRIPTION
# Modification
## MongoDB
- collection name: `subscriptionData.msisdnSupiMap` 改為 `subscriptionData.identityData`
- 原本 gpsi 的欄位是 `msisdn: "0998774634"`，我將欄位名稱改為 gpsi 並且字串內多了 prefix `"msisdn-"`

![image](https://hackmd.io/_uploads/rJZgqtVNT.png)

- collection `subscriptionData.ProvisionedData.amData` 內部也會存 gpsis 的資料，這邊寫入的地方我也有做修改，否則會存成 `"msisdn-msisdn-..."`。

![image](https://hackmd.io/_uploads/HJPSnK44p.png)

## Frontend 
Create Subscriber，將原本的 MSISDN 提示改為 GPSI (MSISDN)。
- 目前前端只支援 MSISDN 格式，其他格式後端無法處理 (例如 external identifier: username@realm, TS 23.003)
- 前端只能填入一個 GPSI (MSISDN)，但一個 SUPI 可以搭配多個 GPSIs。
![image](https://hackmd.io/_uploads/rJ-D9KVEp.png)
View Subscriber:
![image](https://hackmd.io/_uploads/S1dO5KEVp.png)