### PR TITLE
Disable Billing Server If Needed

### DIFF
--- a/backend/factory/config.go
+++ b/backend/factory/config.go
@@ -64,6 +64,7 @@ type Tls struct {
 }
 
 type BillingServer struct {
+	Enabled    bool   `yaml:"enabled" valid:"type(bool), default(true)"`
 	HostIPv4   string `yaml:"hostIPv4,omitempty" valid:"required,host"`
 	Port       int    `yaml:"port,omitempty" valid:"optional,port"`
 	ListenPort int    `yaml:"listenPort,omitempty" valid:"required,port"`

--- a/backend/factory/config.go
+++ b/backend/factory/config.go
@@ -64,7 +64,7 @@ type Tls struct {
 }
 
 type BillingServer struct {
-	Enabled    bool   `yaml:"enabled" valid:"type(bool), default(true)"`
+	Enable     bool   `yaml:"enable" valid:"type(bool), default(true)"`
 	HostIPv4   string `yaml:"hostIPv4,omitempty" valid:"required,host"`
 	Port       int    `yaml:"port,omitempty" valid:"optional,port"`
 	ListenPort int    `yaml:"listenPort,omitempty" valid:"required,port"`

--- a/backend/webui_service/webui_init.go
+++ b/backend/webui_service/webui_init.go
@@ -110,7 +110,7 @@ func (a *WebuiApp) Start(tlsKeyLogPath string) {
 
 	wg := sync.WaitGroup{}
 
-	if billingServer.Enabled {
+	if billingServer.Enable {
 		wg.Add(1)
 		self.BillingServer = billing.OpenServer(&wg)
 		if self.BillingServer == nil {

--- a/backend/webui_service/webui_init.go
+++ b/backend/webui_service/webui_init.go
@@ -73,6 +73,7 @@ func (a *WebuiApp) Start(tlsKeyLogPath string) {
 	// get config file info from WebUIConfig
 	mongodb := factory.WebuiConfig.Configuration.Mongodb
 	webServer := factory.WebuiConfig.Configuration.WebServer
+	billingServer := factory.WebuiConfig.Configuration.BillingServer
 
 	// Connect to MongoDB
 	if err := mongoapi.SetMongoDB(mongodb.Name, mongodb.Url); err != nil {
@@ -108,11 +109,13 @@ func (a *WebuiApp) Start(tlsKeyLogPath string) {
 	self.UpdateNfProfiles()
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
 
-	self.BillingServer = billing.OpenServer(&wg)
-	if self.BillingServer == nil {
-		logger.InitLog.Errorln("Billing Server open error.")
+	if billingServer.Enabled {
+		wg.Add(1)
+		self.BillingServer = billing.OpenServer(&wg)
+		if self.BillingServer == nil {
+			logger.InitLog.Errorln("Billing Server open error.")
+		}
 	}
 
 	router.NoRoute(ReturnPublic())

--- a/config/webuicfg.yaml
+++ b/config/webuicfg.yaml
@@ -12,6 +12,7 @@ configuration:
     ipv4Address: 0.0.0.0
     port: 5000
   billingServer:
+    enable: true
     hostIPv4: 127.0.0.1
     listenPort: 2122
     port: 2121


### PR DESCRIPTION
# Description

Billing server (FTP server) should be able to be disabled if there's no CHF deployed.

# What has been done?

- Add new config attribute `configuration.billingServer.enable`
- If `configuration.billingServer.enable` is `false`, no billing server will start.