### PR TITLE
Fix: billingServer config adjustment

### DIFF
--- a/backend/factory/config.go
+++ b/backend/factory/config.go
@@ -64,7 +64,7 @@ type Tls struct {
 }
 
 type BillingServer struct {
-	Enable     bool   `yaml:"enable" valid:"type(bool), default(true)"`
+	Enable     bool   `yaml:"enable,omitempty" valid:"required,type(bool)"`
 	HostIPv4   string `yaml:"hostIPv4,omitempty" valid:"required,host"`
 	Port       int    `yaml:"port,omitempty" valid:"optional,port"`
 	ListenPort int    `yaml:"listenPort,omitempty" valid:"required,port"`


### PR DESCRIPTION
## Description
- BillingServer enable config set to `required`
- Remove default value to enable or not