### PR TITLE
feat: Implement page refresh

### DIFF
--- a/backend/webui_service/webui_init.go
+++ b/backend/webui_service/webui_init.go
@@ -137,7 +137,7 @@ func (a *WebuiApp) Start(tlsKeyLogPath string) {
 		AllowMethods: []string{"GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"},
 		AllowHeaders: []string{
 			"Origin", "Content-Length", "Content-Type", "User-Agent",
-			"Referrer", "Host", "Token", "X-Requested-With",
+			"Referrer", "Host", "Authorization", "Token", "X-Requested-With",
 		},
 		ExposeHeaders:    []string{"Content-Length"},
 		AllowCredentials: true,

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -88,6 +88,74 @@ function Dashboard(props: DashboardProps) {
   }
   const { user } = context;
 
+  const navigation = useNavigate();
+
+  const [time, setTime] = useState<Date>(new Date());
+  const [refreshInterval, setRefreshInterval] = useState(0);
+  const [refreshString, setRefreshString] = useState("manual");
+
+  // execute every time the refreshInterval changes to set the interval correctly
+  // update the time value every x ms, which triggers refresh (see below)
+  useEffect(() => {
+    if (refreshInterval === 0) {
+      console.log("refreshInterval is 0");
+      return;
+    }
+    const interval = setInterval(() => setTime(new Date()), refreshInterval);
+    return () => {
+      console.log("clear refreshInterval");
+      clearInterval(interval);
+    };
+  }, [refreshInterval]);
+
+  // refresh every time the 'time' value changes
+  useEffect(() => {
+    console.log("reload page at", time.toISOString());
+    props.refreshAction();
+  }, [time]);
+
+  const handleUserNameClick = (event: React.MouseEvent<HTMLElement>, index: number) => {
+    switch (index) {
+      case 0:
+        navigation("/password");
+        break;
+      case 1:
+        // setUser(null);
+        navigation("/login");
+        break;
+      default:
+        break;
+    }
+  };
+
+  const refreshStrings = ["manual", "1s", "5s", "10s", "30s"];
+
+  const handleRefreshClick = (event: React.MouseEvent<HTMLElement>, index: number) => {
+    switch (index) {
+      case 0: // manual
+        setRefreshInterval(0);
+        setRefreshString(refreshStrings.at(index)!);
+        break;
+      case 1: // 1s
+        setRefreshInterval(1000);
+        setRefreshString(refreshStrings.at(index)!);
+        break;
+      case 2: // 5s
+        setRefreshInterval(5000);
+        setRefreshString(refreshStrings.at(index)!);
+        break;
+      case 3: // 10s
+        setRefreshInterval(10000);
+        setRefreshString(refreshStrings.at(index)!);
+        break;
+      case 4: // 30s
+        setRefreshInterval(30000);
+        setRefreshString(refreshStrings.at(index)!);
+        break;
+      default:
+        break;
+    }
+  };
   return (
     <ThemeProvider theme={mdTheme}>
       <Box sx={{ display: "flex" }}>

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -82,75 +82,11 @@ function Dashboard(props: DashboardProps) {
   const toggleDrawer = () => {
     setOpen(!open);
   };
-  const { user, setUser } = useContext(LoginContext);
-  const navigation = useNavigate();
-
-  const [time, setTime] = useState<Date>(new Date());
-  const [refreshInterval, setRefreshInterval] = useState(0);
-  const [refreshString, setRefreshString] = useState("manual");
-
-  // execute every time the refreshInterval changes to set the interval correctly
-  // update the time value every x ms, which triggers refresh (see below)
-  useEffect(() => {
-    if (refreshInterval === 0) {
-      console.log("refreshInterval is 0");
-      return;
-    }
-    const interval = setInterval(() => setTime(new Date()), refreshInterval);
-    return () => {
-      console.log("clear refreshInterval");
-      clearInterval(interval);
-    };
-  }, [refreshInterval]);
-
-  // refresh every time the 'time' value changes
-  useEffect(() => {
-    console.log("reload page at", time.toISOString());
-    props.refreshAction();
-  }, [time]);
-
-  const handleUserNameClick = (event: React.MouseEvent<HTMLElement>, index: number) => {
-    switch (index) {
-      case 0:
-        navigation("/password");
-        break;
-      case 1:
-        setUser(null);
-        navigation("/login");
-        break;
-      default:
-        break;
-    }
-  };
-
-  const refreshStrings = ["manual", "1s", "5s", "10s", "30s"];
-
-  const handleRefreshClick = (event: React.MouseEvent<HTMLElement>, index: number) => {
-    switch (index) {
-      case 0: // manual
-        setRefreshInterval(0);
-        setRefreshString(refreshStrings.at(index)!);
-        break;
-      case 1: // 1s
-        setRefreshInterval(1000);
-        setRefreshString(refreshStrings.at(index)!);
-        break;
-      case 2: // 5s
-        setRefreshInterval(5000);
-        setRefreshString(refreshStrings.at(index)!);
-        break;
-      case 3: // 10s
-        setRefreshInterval(10000);
-        setRefreshString(refreshStrings.at(index)!);
-        break;
-      case 4: // 30s
-        setRefreshInterval(30000);
-        setRefreshString(refreshStrings.at(index)!);
-        break;
-      default:
-        break;
-    }
-  };
+  const context = useContext(LoginContext);
+  if (context === undefined) {
+    throw new Error("LoginContext must be used within a LoginContext.Provider");
+  }
+  const { user } = context;
 
   return (
     <ThemeProvider theme={mdTheme}>

--- a/frontend/src/LoginContext.tsx
+++ b/frontend/src/LoginContext.tsx
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { Dispatch, SetStateAction, createContext } from "react";
 
 export interface User {
   username: string;
@@ -7,12 +7,7 @@ export interface User {
 
 export interface UserContext {
   user: User | null;
-  setUser: (user: User | null) => void;
+  setUser: Dispatch<SetStateAction<User | null>>;
 }
 
-export const LoginContext = createContext<UserContext>({
-  user: null,
-  setUser: (user: User | null) => {
-    console.log(user);
-  },
-});
+export const LoginContext = createContext<UserContext | undefined>(undefined);

--- a/frontend/src/ProtectedRoute.tsx
+++ b/frontend/src/ProtectedRoute.tsx
@@ -1,10 +1,14 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { Navigate } from "react-router-dom";
 
 import { LoginContext } from "./LoginContext";
 
 export const ProtectedRoute = (props: any) => {
-  const { user } = useContext(LoginContext);
+  const context = useContext(LoginContext);
+  if (context === undefined) {
+    throw new Error("LoginContext must be used within a LoginContext.Provider");
+  }
+  const { user } = context;
 
   if (user === null) {
     return <Navigate to="/login" />;

--- a/frontend/src/SimpleListMenu.tsx
+++ b/frontend/src/SimpleListMenu.tsx
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
+import { useNavigate } from "react-router-dom";
+import { LoginContext } from "./LoginContext";
 
 export interface SimpleListMenuProps {
   title: string | undefined;

--- a/frontend/src/SimpleListMenu.tsx
+++ b/frontend/src/SimpleListMenu.tsx
@@ -19,6 +19,37 @@ export default function SimpleListMenu(props: SimpleListMenuProps) {
     setAnchorEl(event.currentTarget);
   };
 
+  const navigation = useNavigate();
+  const context = useContext(LoginContext);
+  if (context === undefined) {
+    throw new Error("LoginContext must be used within a LoginContext.Provider");
+  }
+  const { setUser } = context;
+
+  function onChangePassword() {
+    navigation("/password");
+  }
+
+  function onLogout() {
+    setUser(null);
+    navigation("/login");
+  }
+
+  const handleMenuItemClick = (event: React.MouseEvent<HTMLElement>, index: number) => {
+    setSelectedIndex(index);
+    setAnchorEl(null);
+    switch (index) {
+      case 0:
+        onChangePassword();
+        break;
+      case 1:
+        onLogout();
+        break;
+      default:
+        break;
+    }
+  };
+
   const handleClose = () => {
     setAnchorEl(null);
   };

--- a/frontend/src/axios.tsx
+++ b/frontend/src/axios.tsx
@@ -9,7 +9,27 @@ if (process.env.NODE_ENV === "development") {
 } else {
   apiConfig.API_URL = process.env.REACT_APP_HTTP_API_URL ? process.env.REACT_APP_HTTP_API_URL : "";
 }
+
 const instance = axios.create({
   baseURL: apiConfig.API_URL,
 });
+
+// attach the token to every request
+instance.interceptors.request.use(
+  config => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      // add the token to the header
+      console.log('adding token to axios header');
+      config.headers.Token = `${token}`;
+    } else {
+      console.warn('no token in local storage!');
+    }
+    return config;
+  },
+  error => {
+    return Promise.reject(error);
+  }
+);
+
 export default instance;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -17,7 +17,11 @@ const theme = createTheme();
 export default function SignIn() {
   const navigation = useNavigate();
   const [error, setError] = useState<string>("");
-  const { setUser } = useContext(LoginContext);
+  const context = useContext(LoginContext);
+  if (context === undefined) {
+    throw new Error("LoginContext must be used within a LoginContext.Provider");
+  }
+  const { setUser } = context;
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -28,12 +32,11 @@ export default function SignIn() {
         if (data.get("email") !== null) {
           setUser({ username: data.get("email")!.toString(), token: res.data.access_token });
         }
-        axios.defaults.headers.common.Token = res.data.access_token;
         setError("");
         navigation("/");
       })
       .catch((err) => {
-        console.log(err);
+        console.log(err.message);
         setError("Wrong credentials");
       });
   };

--- a/frontend/src/pages/Logout.tsx
+++ b/frontend/src/pages/Logout.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
@@ -9,7 +9,11 @@ import { LoginContext } from "../LoginContext";
 
 export const Logout = () => {
   const navigation = useNavigate();
-  const { setUser } = useContext(LoginContext);
+  const context = useContext(LoginContext);
+  if (context === undefined) {
+    throw new Error("LoginContext must be used within a LoginContext.Provider");
+  }
+  const { setUser } = context;
 
   function onLogout() {
     setUser(null);


### PR DESCRIPTION
I noticed that the webconsole does not retain login information when the page is refreshed.
Using local storage, I implemented this missing functionality.
I also configured the axios token so that it survives page refreshes.