### PR TITLE
fix: rendering errors (missing key and h3 child of TableHeader)

### DIFF
--- a/frontend/src/pages/Charging/ChargingList.tsx
+++ b/frontend/src/pages/Charging/ChargingList.tsx
@@ -79,7 +79,11 @@ const ChargingList: React.FC<{
   return (
     <Table>
       <TableHead>
-        <h3>{props.chargingMethod} Charging</h3>
+        <TableRow>
+          <TableCell colSpan={tableColumnNames.length}>
+            <h3>{props.chargingMethod} Charging</h3>
+          </TableCell>
+        </TableRow>
         <TableRow>
           {tableColumnNames.map((colName, idx) => {
             return <TableCell key={idx}>{colName}</TableCell>;
@@ -91,8 +95,8 @@ const ChargingList: React.FC<{
           .filter((a) => a!.filter === "" && a!.dnn === "")
           .map((cd, idx) => {
             return (
-              <>
-                <TableRow key={idx}>
+              <React.Fragment key={idx}>
+                <TableRow>
                   <TableCell>{cd.ueId}</TableCell>
                   <TableCell>{cd.snssai}</TableCell>
                   <TableCell>{cd.dnn}</TableCell>
@@ -105,7 +109,7 @@ const ChargingList: React.FC<{
                   />
                 </TableRow>
                 {<PerFlowTableView Supi={cd.ueId!} Snssai={cd.snssai!} />}
-              </>
+              </React.Fragment>
             );
           })}
       </TableBody>


### PR DESCRIPTION
The charging table page showed two errors:
1. The table did not have unique keys/ identifiers for every row due to wrapping each TableRow in a fragment (<>...</>), which doesn't pass the key prop down to the actual TableRow component.
2. The table header was not correctly using the `<h3>` tag, which cannot be a direct child of TableHead

I fixed these errors, sorry for the small PR.