### PR TITLE
fix: empty qosflow field in both profile and subscriber page

### DIFF
--- a/frontend/src/pages/Component/FlowRule.tsx
+++ b/frontend/src/pages/Component/FlowRule.tsx
@@ -7,23 +7,31 @@ import {
     TableRow,
     TableCell,
 } from "@mui/material";
-import { QosFlows, Nssai } from "../../api/api";
+import { Nssai } from "../../api/api";
+
+const qosFlow = (qosflows: any, sstSd: string, dnn: string, qosRef: number | undefined) => {
+    if (qosflows === null) {
+        return undefined;
+    }
+    for (const qos of qosflows) {
+        if (qos.snssai === sstSd && qos.dnn === dnn && qos.qosRef === qosRef) {
+            return qos;
+        }
+    }
+    return undefined;
+}
 
 const FlowRule = ({
     dnn,
     flow,
     data,
     chargingConfig,
-    qosFlow,
 }: {
     dnn: string;
     flow: any;
     data: any;
     chargingConfig: (dnn: string, snssai: Nssai, filter: string | undefined) => JSX.Element | undefined;
-    qosFlow: (sstSd: string, dnn: string, qosRef: number | undefined) => QosFlows | undefined;
 }) => {
-    const flowKey = toHex(flow.sst) + flow.sd;
-
     return (
         <div key={flow.snssai}>
             <Box sx={{ m: 2 }}>
@@ -41,23 +49,23 @@ const FlowRule = ({
                             </TableRow>
                             <TableRow>
                                 <TableCell style={{ width: "40%" }}>5QI</TableCell>
-                                <TableCell>{qosFlow(flowKey, dnn, flow.qosRef)?.["5qi"]}</TableCell>
+                                <TableCell>{qosFlow(data.QosFlows, flow.snssai, dnn, flow.qosRef!)?.["5qi"]}</TableCell>
                             </TableRow>
                             <TableRow>
                                 <TableCell style={{ width: "40%" }}>Uplink GBR</TableCell>
-                                <TableCell>{qosFlow(flowKey, dnn, flow.qosRef!)?.gbrUL}</TableCell>
+                                <TableCell>{qosFlow(data.QosFlows, flow.snssai, dnn, flow.qosRef!)?.gbrUL}</TableCell>
                             </TableRow>
                             <TableRow>
                                 <TableCell style={{ width: "40%" }}>Downlink GBR</TableCell>
-                                <TableCell>{qosFlow(flowKey, dnn, flow.qosRef!)?.gbrDL}</TableCell>
+                                <TableCell>{qosFlow(data.QosFlows, flow.snssai, dnn, flow.qosRef!)?.gbrDL}</TableCell>
                             </TableRow>
                             <TableRow>
                                 <TableCell style={{ width: "40%" }}>Uplink MBR</TableCell>
-                                <TableCell>{qosFlow(flowKey, dnn, flow.qosRef!)?.mbrUL}</TableCell>
+                                <TableCell>{qosFlow(data.QosFlows, flow.snssai, dnn, flow.qosRef!)?.mbrUL}</TableCell>
                             </TableRow>
                             <TableRow>
                                 <TableCell style={{ width: "40%" }}>Downlink MBR</TableCell>
-                                <TableCell>{qosFlow(flowKey, dnn, flow.qosRef!)?.mbrDL}</TableCell>
+                                <TableCell>{qosFlow(data.QosFlows, flow.snssai, dnn, flow.qosRef!)?.mbrDL}</TableCell>
                             </TableRow>
                             <TableRow>
                                 <TableCell style={{ width: "40%" }}>Charging Characteristics</TableCell>
@@ -69,10 +77,6 @@ const FlowRule = ({
             </Box>
         </div>
     );
-};
-
-const toHex = (v: number | undefined): string => {
-    return ("00" + v?.toString(16).toUpperCase()).substr(-2);
 };
 
 export default FlowRule;

--- a/frontend/src/pages/ProfileRead.tsx
+++ b/frontend/src/pages/ProfileRead.tsx
@@ -3,7 +3,11 @@ import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
 import axios from "../axios";
-import { Nssai, Profile, QosFlows, DnnConfiguration } from "../api/api";
+import {
+  Nssai,
+  Profile,
+  DnnConfiguration,
+} from "../api/api";
 
 import Dashboard from "../Dashboard";
 import {
@@ -59,21 +63,6 @@ export default function ProfileRead() {
     }
   };
 
-  const qosFlow = (
-    sstSd: string,
-    dnn: string,
-    qosRef: number | undefined,
-  ): QosFlows | undefined => {
-    if (data != null) {
-      for (const qos of data.QosFlows) {
-        if (qos.snssai === sstSd && qos.dnn === dnn && qos.qosRef === qosRef) {
-          return qos;
-        }
-      }
-    }
-    return undefined;
-  };
-
   const chargingConfig = (dnn: string, snssai: Nssai, filter: string | undefined) => {
     const flowKey = toHex(snssai.sst) + snssai.sd;
     for (const chargingData of data?.ChargingDatas ?? []) {
@@ -95,12 +84,10 @@ export default function ProfileRead() {
     return data.FlowRules.filter((flow) => flow.dnn === dnn && flow.snssai === flowKey).map(
       (flow) => (
         <FlowRule
-          key={flow.snssai}
           flow={flow}
           dnn={dnn}
           data={data}
-          chargingConfig={chargingConfig}
-          qosFlow={qosFlow}
+          chargingConfig={() => chargingConfig(dnn, snssai, flow.filter)}
         />
       ),
     );

--- a/frontend/src/pages/SubscriberRead.tsx
+++ b/frontend/src/pages/SubscriberRead.tsx
@@ -9,7 +9,6 @@ import {
   AuthenticationSubscription,
   AccessAndMobilitySubscriptionData,
   DnnConfiguration,
-  QosFlows,
 } from "../api/api";
 
 import Dashboard from "../Dashboard";
@@ -25,8 +24,9 @@ import {
   TableRow,
 } from "@mui/material";
 import FlowRule from "./Component/FlowRule";
-import ChargingCfg from "./Component/ChargingCfg";
 import UpSecurity from "./Component/UpSecurity";
+import { toHex } from "../lib/utils";
+import ChargingCfg from "./Component/ChargingCfg";
 
 export default function SubscriberRead() {
   const { id, plmn } = useParams<{
@@ -37,10 +37,6 @@ export default function SubscriberRead() {
 
   const [data, setData] = useState<Subscription | null>(null);
   // const [update, setUpdate] = useState<boolean>(false);
-
-  function toHex(v: number | undefined): string {
-    return ("00" + v?.toString(16).toUpperCase()).substr(-2);
-  }
 
   useEffect(() => {
     axios.get("/api/subscriber/" + id + "/" + plmn).then((res) => {
@@ -121,20 +117,6 @@ export default function SubscriberRead() {
     return "";
   };
 
-  const qosFlow = (
-    sstSd: string,
-    dnn: string,
-    qosRef: number | undefined,
-  ): QosFlows | undefined => {
-    if (data != null) {
-      for (const qos of data.QosFlows) {
-        if (qos.snssai === sstSd && qos.dnn === dnn && qos.qosRef === qosRef) {
-          return qos;
-        }
-      }
-    }
-  };
-
   const chargingConfig = (dnn: string, snssai: Nssai, filter: string | undefined) => {
     const flowKey = toHex(snssai.sst) + snssai.sd;
     for (const chargingData of data?.ChargingDatas ?? []) {
@@ -160,8 +142,7 @@ export default function SubscriberRead() {
           flow={flow}
           dnn={dnn}
           data={data}
-          chargingConfig={chargingConfig}
-          qosFlow={qosFlow}
+          chargingConfig={() => chargingConfig(dnn, snssai, flow.filter)}
         />
       ),
     );


### PR DESCRIPTION
In the Profile and Subscriber pages, there is an issue where the QoS Flow and its Charging Characteristics are displayed incorrectly, with the fields appearing empty.

Now, it is fixed:
![Screenshot 2024-12-04 025520](https://github.com/user-attachments/assets/61d62b29-d0de-496b-be3b-535bfc1288c2)
