### PR TITLE
fix: use controller to track the switch status

### DIFF
--- a/frontend/src/pages/SubscriberCreate/SubscriberFormSessions.tsx
+++ b/frontend/src/pages/SubscriberCreate/SubscriberFormSessions.tsx
@@ -262,9 +262,14 @@ export default function SubscriberFormSessions() {
                       <TableBody>
                         <TableRow>
                           <TableCell style={{ width: "10%" }}>
-                            <Switch
-                              {...register(
-                                `SnssaiConfigurations.${index}.dnnConfigurations.${dnn}.enableStaticIpv4Address`,
+                            <Controller
+                              control={control}
+                              name={`SnssaiConfigurations.${index}.dnnConfigurations.${dnn}.enableStaticIpv4Address`}
+                              render={({ field }) => (
+                                <Switch
+                                  checked={field.value}
+                                  onChange={(e) => field.onChange(e.target.checked)}
+                                />
                               )}
                             />
                           </TableCell>


### PR DESCRIPTION
Instead of using `switch`, I update this section with `controller`. It provides a stronger status track function which makes the switch display correct.

UE side test is work well as before.