### PR TITLE
fix: miss static ip in edit page

### DIFF
--- a/frontend/src/lib/dtos/subscription.ts
+++ b/frontend/src/lib/dtos/subscription.ts
@@ -345,6 +345,7 @@ class SubscriptionMapperImpl implements SubscriptionMapper {
                 downlink: value.sessionAmbr?.downlink ?? "",
               },
               enableStaticIpv4Address: value.staticIpAddress?.length !== 0,
+              staticIpv4Address: value.staticIpAddress?.[0]?.ipv4Addr ?? "",
               flowRules: this.parseDnnFlowRules(s.singleNssai, key, subscription),
               upSecurity: value.upSecurity,
             } satisfies DnnConfigurationDTO,


### PR DESCRIPTION
There is a static ip miss in subscription dtos.