### PR TITLE
fix: require auth and tenant scoping on GetUEPDUSessionInfo

### DIFF
--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -1808,6 +1808,16 @@ func GetUEPDUSessionInfo(c *gin.Context) {
 		return
 	}
 
+	isAdmin := CheckAuth(c)
+	tenantId, err := GetTenantId(c)
+	if err != nil {
+		logger.ProcLog.Errorln(err.Error())
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"cause": "Illegal or Nil token",
+		})
+		return
+	}
+
 	// TODO: support fetching data from multiple SMF
 	if smfUris := webuiSelf.GetOamUris(models.NrfNfManagementNfType_SMF); smfUris != nil {
 		requestUri := fmt.Sprintf("%s/nsmf-oam/v1/ue-pdu-session-info/%s", smfUris[0], smContextRef)
@@ -1843,12 +1853,55 @@ func GetUEPDUSessionInfo(c *gin.Context) {
 				logger.ProcLog.Error(closeErr)
 			}
 		}()
-		sendResponseToClient(c, resp)
+
+		if isAdmin {
+			sendResponseToClient(c, resp)
+		} else {
+			sendResponseToClientFilterTenantSingle(c, resp, tenantId)
+		}
 	} else {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"cause": "No SMF Found",
 		})
 	}
+}
+
+// sendResponseToClientFilterTenantSingle forwards a single-object OAM response
+// (e.g. SMF ue-pdu-session-info) only when its Supi belongs to the caller's
+// tenant, so a non-admin user cannot read another tenant's PDU session.
+func sendResponseToClientFilterTenantSingle(c *gin.Context, response *http.Response, tenantId string) {
+	filterTenantIdOnly := bson.M{"tenantId": tenantId}
+	amDataList, err := mongoapi.RestfulAPIGetMany(amDataColl, filterTenantIdOnly)
+	if err != nil {
+		logger.ProcLog.Errorf("sendResponseToClientFilterTenantSingle err: %+v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{})
+		return
+	}
+
+	tenantCheck := func(supi string) bool {
+		for _, amData := range amDataList {
+			if supi == amData["ueId"] {
+				return true
+			}
+		}
+		return false
+	}
+
+	var jsonData map[string]interface{}
+	if err = json.NewDecoder(response.Body).Decode(&jsonData); err != nil {
+		logger.ProcLog.Errorf("sendResponseToClientFilterTenantSingle err: %+v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{})
+		return
+	}
+
+	if supi, ok := jsonData["Supi"].(string); ok && tenantCheck(supi) {
+		c.JSON(response.StatusCode, jsonData)
+		return
+	}
+
+	c.JSON(http.StatusForbidden, gin.H{
+		"cause": "Subscriber does not belong to this tenant",
+	})
 }
 
 func ChangePasswordInfo(c *gin.Context) {

--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -1872,38 +1872,42 @@ func GetUEPDUSessionInfo(c *gin.Context) {
 // (e.g. SMF ue-pdu-session-info) only when its Supi belongs to the caller's
 // tenant, so a non-admin user cannot read another tenant's PDU session.
 func sendResponseToClientFilterTenantSingle(c *gin.Context, response *http.Response, tenantId string) {
-	filterTenantIdOnly := bson.M{"tenantId": tenantId}
-	amDataList, err := mongoapi.RestfulAPIGetMany(amDataColl, filterTenantIdOnly)
+	// Preserve upstream error responses as-is; only apply tenant check on success.
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		sendResponseToClient(c, response)
+		return
+	}
+
+	var jsonData map[string]interface{}
+	if err := json.NewDecoder(response.Body).Decode(&jsonData); err != nil {
+		logger.ProcLog.Errorf("sendResponseToClientFilterTenantSingle err: %+v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{})
+		return
+	}
+
+	supi, ok := jsonData["Supi"].(string)
+	if !ok || supi == "" {
+		c.JSON(http.StatusForbidden, gin.H{
+			"cause": "Subscriber does not belong to this tenant",
+		})
+		return
+	}
+
+	// Point query instead of loading all tenant rows (avoids O(N) scan).
+	amData, err := mongoapi.RestfulAPIGetOne(amDataColl, bson.M{"tenantId": tenantId, "ueId": supi})
 	if err != nil {
 		logger.ProcLog.Errorf("sendResponseToClientFilterTenantSingle err: %+v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{})
 		return
 	}
-
-	tenantCheck := func(supi string) bool {
-		for _, amData := range amDataList {
-			if supi == amData["ueId"] {
-				return true
-			}
-		}
-		return false
-	}
-
-	var jsonData map[string]interface{}
-	if err = json.NewDecoder(response.Body).Decode(&jsonData); err != nil {
-		logger.ProcLog.Errorf("sendResponseToClientFilterTenantSingle err: %+v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{})
+	if len(amData) == 0 {
+		c.JSON(http.StatusForbidden, gin.H{
+			"cause": "Subscriber does not belong to this tenant",
+		})
 		return
 	}
 
-	if supi, ok := jsonData["Supi"].(string); ok && tenantCheck(supi) {
-		c.JSON(response.StatusCode, jsonData)
-		return
-	}
-
-	c.JSON(http.StatusForbidden, gin.H{
-		"cause": "Subscriber does not belong to this tenant",
-	})
+	c.JSON(response.StatusCode, jsonData)
 }
 
 func ChangePasswordInfo(c *gin.Context) {

--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -1830,7 +1830,8 @@ func GetUEPDUSessionInfo(c *gin.Context) {
 			return
 		}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUri, nil)
+		var req *http.Request
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, requestUri, nil)
 		if err != nil {
 			logger.ProcLog.Error(err)
 			c.JSON(http.StatusInternalServerError, gin.H{})
@@ -1842,7 +1843,8 @@ func GetUEPDUSessionInfo(c *gin.Context) {
 			return
 		}
 
-		resp, err := httpsClient.Do(req)
+		var resp *http.Response
+		resp, err = httpsClient.Do(req)
 		if err != nil {
 			logger.ProcLog.Error(err)
 			c.JSON(http.StatusInternalServerError, gin.H{})


### PR DESCRIPTION
fixing https://github.com/free5gc/free5gc/issues/1074

## Problem
`GetUEPDUSessionInfo` (`GET /api/ue-pdu-session-info/:smContextRef`) performed no authentication or authorization. It minted the WebConsole's own NF OAuth2 token and proxied the request to the internal SMF OAM interface, returning the response verbatim to the caller. It's a confused-deputy that lets a request without a valid token read a UE's PDU session info.
It also applied no tenant filtering, unlike the sibling `GetRegisteredUEContext`.

## Fix
- Authenticate the caller with `GetTenantId()` at the top of the handler,
  before the NF token is minted, so unauthorized requests are rejected with
  401 and never reach the SMF OAM proxy.
- Tenant-scope the response for non-admins via a new
  `sendResponseToClientFilterTenantSingle` helper. The existing
  `sendResponseToClientFilterTenant` only filters slices and would pass the
  SMF's single-object response through unfiltered, leaving cross-tenant reads
  possible.
