### PR TITLE
fix: require auth for subscriber APIs to prevent unauthenticated access

### DIFF
--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -55,6 +55,12 @@ var jwtKey = "" // for generating JWT
 
 var httpsClient *http.Client
 
+const (
+	authClaimsContextKey = "authClaims"
+	authTenantContextKey = "authTenantId"
+	authAdminContextKey  = "authIsAdmin"
+)
+
 func init() {
 	httpsClient = &http.Client{
 		Transport: &http.Transport{
@@ -380,46 +386,135 @@ type AuthSub struct {
 
 // Parse JWT
 func ParseJWT(tokenStr string) (jwt.MapClaims, error) {
+	if tokenStr == "" {
+		return nil, fmt.Errorf("no token in header")
+	}
+
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+
 		// Tolerance for User's Time quicker than Server's time
-		mapClaims := token.Claims.(jwt.MapClaims)
-		delete(mapClaims, "iat")
+		if mapClaims, ok := token.Claims.(jwt.MapClaims); ok {
+			delete(mapClaims, "iat")
+		}
 		return []byte(jwtKey), nil
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "ParseJWT error")
 	}
+	if token == nil || !token.Valid {
+		return nil, fmt.Errorf("invalid token")
+	}
 
-	claims, _ := token.Claims.(jwt.MapClaims)
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("invalid token claims")
+	}
 
 	return claims, nil
 }
 
+func getClaimString(claims jwt.MapClaims, key string) (string, bool) {
+	value, ok := claims[key]
+	if !ok {
+		return "", false
+	}
+
+	stringValue, ok := value.(string)
+	if !ok || stringValue == "" {
+		return "", false
+	}
+
+	return stringValue, true
+}
+
+func claimsFromContext(c *gin.Context) (jwt.MapClaims, bool) {
+	value, exists := c.Get(authClaimsContextKey)
+	if !exists {
+		return nil, false
+	}
+
+	claims, ok := value.(jwt.MapClaims)
+	return claims, ok
+}
+
+func getAuthenticatedClaims(c *gin.Context) (jwt.MapClaims, error) {
+	if claims, ok := claimsFromContext(c); ok {
+		return claims, nil
+	}
+
+	return ParseJWT(c.GetHeader("Token"))
+}
+
+func isAdminClaims(claims jwt.MapClaims) bool {
+	email, ok := getClaimString(claims, "email")
+	return ok && email == "admin"
+}
+
+func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method == http.MethodOptions ||
+			(c.Request.Method == http.MethodPost && c.Request.URL.Path == "/api/login") {
+			c.Next()
+			return
+		}
+
+		claims, err := ParseJWT(c.GetHeader("Token"))
+		if err != nil {
+			logger.ProcLog.Errorln(err.Error())
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"cause": "Illegal Token"})
+			return
+		}
+
+		tenantId, ok := getClaimString(claims, "tenantId")
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"cause": "Illegal Token"})
+			return
+		}
+
+		c.Set(authClaimsContextKey, claims)
+		c.Set(authTenantContextKey, tenantId)
+		c.Set(authAdminContextKey, isAdminClaims(claims))
+		c.Next()
+	}
+}
+
 // Check of admin user. This should be done with proper JWT token.
 func CheckAuth(c *gin.Context) bool {
-	tokenStr := c.GetHeader("Token")
-	claims, err := ParseJWT(tokenStr)
+	if isAdmin, exists := c.Get(authAdminContextKey); exists {
+		if isAdminBool, ok := isAdmin.(bool); ok {
+			return isAdminBool
+		}
+	}
+
+	claims, err := getAuthenticatedClaims(c)
 	if err != nil {
 		return false
 	}
-	if claims["email"].(string) == "admin" {
-		return true
-	} else {
-		return false
-	}
+	return isAdminClaims(claims)
 }
 
 // Tenant ID
 func GetTenantId(c *gin.Context) (string, error) {
-	tokenStr := c.GetHeader("Token")
-	if tokenStr == "" {
-		return "", fmt.Errorf("no token in header")
+	if tenantId, exists := c.Get(authTenantContextKey); exists {
+		if tenantIdString, ok := tenantId.(string); ok && tenantIdString != "" {
+			return tenantIdString, nil
+		}
 	}
-	claims, err := ParseJWT(tokenStr)
+
+	claims, err := getAuthenticatedClaims(c)
 	if err != nil {
 		return "", errors.Wrap(err, "GetTenantId error")
 	}
-	return claims["tenantId"].(string), nil
+
+	tenantId, ok := getClaimString(claims, "tenantId")
+	if !ok {
+		return "", fmt.Errorf("tenantId not found in token")
+	}
+
+	return tenantId, nil
 }
 
 // Tenant
@@ -882,11 +977,126 @@ func GetSubscribers(c *gin.Context) {
 	c.JSON(http.StatusOK, subsList)
 }
 
+func getSubscriberAMData(ueId string, servingPlmnId string) (map[string]interface{}, error) {
+	filter := bson.M{"ueId": ueId, "servingPlmnId": servingPlmnId}
+	return mongoapi.RestfulAPIGetOne(amDataColl, filter)
+}
+
+func subscriberTenantID(amData map[string]interface{}) (string, bool) {
+	if len(amData) == 0 {
+		return "", false
+	}
+
+	tenantId, ok := amData["tenantId"].(string)
+	return tenantId, ok && tenantId != ""
+}
+
+func canAccessSubscriberTenant(c *gin.Context, tenantId string) bool {
+	if CheckAuth(c) {
+		return true
+	}
+	if tenantId == "" {
+		return false
+	}
+
+	userTenantId, err := GetTenantId(c)
+	if err != nil {
+		logger.ProcLog.Errorln(err.Error())
+		return false
+	}
+
+	return userTenantId == tenantId
+}
+
+func requireSubscriberAccess(c *gin.Context, ueId string, servingPlmnId string) (map[string]interface{}, bool) {
+	amData, err := getSubscriberAMData(ueId, servingPlmnId)
+	if err != nil {
+		logger.ProcLog.Errorf("requireSubscriberAccess err: %+v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{})
+		return nil, false
+	}
+	if len(amData) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"cause": "subscriber does not exist"})
+		return nil, false
+	}
+
+	tenantId, _ := subscriberTenantID(amData)
+	if !canAccessSubscriberTenant(c, tenantId) {
+		c.JSON(http.StatusForbidden, gin.H{"cause": "Forbidden"})
+		return nil, false
+	}
+
+	return amData, true
+}
+
+func authorizeSubscriberIfExists(
+	c *gin.Context,
+	ueId string,
+	servingPlmnId string,
+) (map[string]interface{}, bool, bool) {
+	amData, err := getSubscriberAMData(ueId, servingPlmnId)
+	if err != nil {
+		logger.ProcLog.Errorf("authorizeSubscriberIfExists err: %+v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{})
+		return nil, false, false
+	}
+	if len(amData) == 0 {
+		return nil, false, true
+	}
+
+	tenantId, _ := subscriberTenantID(amData)
+	if !canAccessSubscriberTenant(c, tenantId) {
+		c.JSON(http.StatusForbidden, gin.H{"cause": "Forbidden"})
+		return nil, true, false
+	}
+
+	return amData, true, true
+}
+
+func claimsWithTenant(claims jwt.MapClaims, tenantId string) jwt.MapClaims {
+	if tenantId == "" {
+		return claims
+	}
+
+	scopedClaims := make(jwt.MapClaims, len(claims))
+	for key, value := range claims {
+		scopedClaims[key] = value
+	}
+	scopedClaims["tenantId"] = tenantId
+	return scopedClaims
+}
+
+func tenantScopedFilter(filter bson.M, claims jwt.MapClaims) bson.M {
+	if claims == nil || isAdminClaims(claims) {
+		return filter
+	}
+
+	tenantId, ok := getClaimString(claims, "tenantId")
+	if !ok {
+		return filter
+	}
+
+	scopedFilter := bson.M{}
+	for key, value := range filter {
+		scopedFilter[key] = value
+	}
+	scopedFilter["tenantId"] = tenantId
+	return scopedFilter
+}
+
 // Get subscriber by IMSI(ueId) and PlmnID(servingPlmnId)
 func GetSubscriberByID(c *gin.Context) {
 	setCorsHeader(c)
 
 	logger.ProcLog.Infoln("Get One Subscriber Data")
+
+	if _, err := getAuthenticatedClaims(c); err != nil {
+		logger.ProcLog.Errorln(err.Error())
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"cause": "Illegal Token (Relogin required)!",
+		})
+		return
+	}
 
 	var subsData SubsData
 
@@ -904,13 +1114,12 @@ func GetSubscriberByID(c *gin.Context) {
 	filterUeIdOnly := bson.M{"ueId": ueId}
 	filter := bson.M{"ueId": ueId, "servingPlmnId": servingPlmnId}
 
-	authSubsDataInterface, err := mongoapi.RestfulAPIGetOne(authWebSubsDataColl, filterUeIdOnly)
-	if err != nil {
-		logger.ProcLog.Errorf("GetSubscriberByID err: %+v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{})
+	amDataDataInterface, ok := requireSubscriberAccess(c, ueId, servingPlmnId)
+	if !ok {
 		return
 	}
-	amDataDataInterface, err := mongoapi.RestfulAPIGetOne(amDataColl, filter)
+
+	authSubsDataInterface, err := mongoapi.RestfulAPIGetOne(authWebSubsDataColl, filterUeIdOnly)
 	if err != nil {
 		logger.ProcLog.Errorf("GetSubscriberByID err: %+v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{})
@@ -1067,8 +1276,7 @@ func PostSubscriberByID(c *gin.Context) {
 	setCorsHeader(c)
 	logger.ProcLog.Infoln("Post One Subscriber Data")
 
-	tokenStr := c.GetHeader("Token")
-	claims, err := ParseJWT(tokenStr)
+	claims, err := getAuthenticatedClaims(c)
 	if err != nil {
 		logger.ProcLog.Errorln(err.Error())
 		c.JSON(http.StatusUnauthorized, gin.H{
@@ -1285,14 +1493,16 @@ func dbOperation(
 			}, bson.M{
 				"$or": multipleFliterConditions,
 			}
+			multipleFliterUeIdOnlyScoped := tenantScopedFilter(multipleFliterUeIdOnly, claims)
+			multipleFliterScoped := tenantScopedFilter(multipleFliter, claims)
 
-			if err := mongoapi.RestfulAPIDeleteMany(authSubsDataColl, multipleFliterUeIdOnly); err != nil {
+			if err := mongoapi.RestfulAPIDeleteMany(authSubsDataColl, multipleFliterUeIdOnlyScoped); err != nil {
 				logger.ProcLog.Errorf("DeleteMultipleSubscribers err: %+v", err)
 			}
-			if err := mongoapi.RestfulAPIDeleteMany(authWebSubsDataColl, multipleFliterUeIdOnly); err != nil {
+			if err := mongoapi.RestfulAPIDeleteMany(authWebSubsDataColl, multipleFliterUeIdOnlyScoped); err != nil {
 				logger.ProcLog.Errorf("DeleteMultipleSubscribers err: %+v", err)
 			}
-			if err := mongoapi.RestfulAPIDeleteMany(amDataColl, multipleFliter); err != nil {
+			if err := mongoapi.RestfulAPIDeleteMany(amDataColl, multipleFliterScoped); err != nil {
 				logger.ProcLog.Errorf("DeleteMultipleSubscribers err: %+v", err)
 			}
 			if err := mongoapi.RestfulAPIDeleteMany(smDataColl, multipleFliter); err != nil {
@@ -1320,13 +1530,16 @@ func dbOperation(
 				logger.ProcLog.Errorf("DeleteMultipleIdnetityDatas err: %+v", err)
 			}
 		} else {
-			if err := mongoapi.RestfulAPIDeleteOne(authSubsDataColl, filterUeIdOnly); err != nil {
+			filterUeIdOnlyScoped := tenantScopedFilter(filterUeIdOnly, claims)
+			filterScoped := tenantScopedFilter(filter, claims)
+
+			if err := mongoapi.RestfulAPIDeleteOne(authSubsDataColl, filterUeIdOnlyScoped); err != nil {
 				logger.ProcLog.Errorf("DeleteSubscriberByID err: %+v", err)
 			}
-			if err := mongoapi.RestfulAPIDeleteOne(authWebSubsDataColl, filterUeIdOnly); err != nil {
+			if err := mongoapi.RestfulAPIDeleteOne(authWebSubsDataColl, filterUeIdOnlyScoped); err != nil {
 				logger.ProcLog.Errorf("DeleteSubscriberByID err: %+v", err)
 			}
-			if err := mongoapi.RestfulAPIDeleteOne(amDataColl, filter); err != nil {
+			if err := mongoapi.RestfulAPIDeleteOne(amDataColl, filterScoped); err != nil {
 				logger.ProcLog.Errorf("DeleteSubscriberByID err: %+v", err)
 			}
 			if err := mongoapi.RestfulAPIDeleteMany(smDataColl, filter); err != nil {
@@ -1366,16 +1579,16 @@ func dbOperation(
 		authSubsBsonM := toBsonM(authSubs)
 		authSubsBsonM["ueId"] = ueId
 
-		if claims != nil {
-			webAuthSubsBsonM["tenantId"] = claims["tenantId"].(string)
-			authSubsBsonM["tenantId"] = claims["tenantId"].(string)
+		if tenantId, ok := getClaimString(claims, "tenantId"); ok {
+			webAuthSubsBsonM["tenantId"] = tenantId
+			authSubsBsonM["tenantId"] = tenantId
 		}
 
 		amDataBsonM := toBsonM(subsData.AccessAndMobilitySubscriptionData)
 		amDataBsonM["ueId"] = ueId
 		amDataBsonM["servingPlmnId"] = servingPlmnId
-		if claims != nil {
-			amDataBsonM["tenantId"] = claims["tenantId"].(string)
+		if tenantId, ok := getClaimString(claims, "tenantId"); ok {
+			amDataBsonM["tenantId"] = tenantId
 		}
 
 		// Replace all data with new one
@@ -1527,6 +1740,16 @@ func dbOperation(
 func PutSubscriberByID(c *gin.Context) {
 	setCorsHeader(c)
 	logger.ProcLog.Infoln("Put One Subscriber Data")
+
+	claims, err := getAuthenticatedClaims(c)
+	if err != nil {
+		logger.ProcLog.Errorln(err.Error())
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"cause": "Illegal Token (Relogin required)!",
+		})
+		return
+	}
+
 	var subsData SubsData
 	if err := c.ShouldBindJSON(&subsData); err != nil {
 		logger.ProcLog.Errorf("PutSubscriberByID err: %v", err)
@@ -1537,6 +1760,16 @@ func PutSubscriberByID(c *gin.Context) {
 	}
 	ueId := c.Param("ueId")
 	servingPlmnId := c.Param("servingPlmnId")
+	amData, exists, ok := authorizeSubscriberIfExists(c, ueId, servingPlmnId)
+	if !ok {
+		return
+	}
+	writeClaims := claims
+	if exists {
+		tenantId, _ := subscriberTenantID(amData)
+		writeClaims = claimsWithTenant(claims, tenantId)
+	}
+
 	// modify a gpsi-supi map
 	gpsi := getMsisdn(toBsonM(subsData.AccessAndMobilitySubscriptionData)["gpsis"])
 	if !validate(ueId, gpsi) {
@@ -1550,8 +1783,7 @@ func PutSubscriberByID(c *gin.Context) {
 	logger.ProcLog.Infof("PutSubscriberByID gpsi: %+v", gpsi)
 	identityDataOperation(ueId, gpsi, "put")
 
-	var claims jwt.MapClaims = nil
-	dbOperation(ueId, servingPlmnId, "put", &subsData, nil, claims, false)
+	dbOperation(ueId, servingPlmnId, "put", &subsData, nil, writeClaims, false)
 	c.Status(http.StatusNoContent)
 }
 
@@ -1559,6 +1791,14 @@ func PutSubscriberByID(c *gin.Context) {
 func PatchSubscriberByID(c *gin.Context) {
 	setCorsHeader(c)
 	logger.ProcLog.Infoln("Patch One Subscriber Data")
+
+	if _, err := getAuthenticatedClaims(c); err != nil {
+		logger.ProcLog.Errorln(err.Error())
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"cause": "Illegal Token (Relogin required)!",
+		})
+		return
+	}
 
 	var subsData SubsData
 	if err := c.ShouldBindJSON(&subsData); err != nil {
@@ -1573,7 +1813,7 @@ func PatchSubscriberByID(c *gin.Context) {
 	supi := gpsiToSupi(ueId)
 	servingPlmnId := c.Param("servingPlmnId")
 	// checking whether gpsi is successfully transformed to supi or not
-	if ueId == "" {
+	if supi == "" {
 		logger.ProcLog.Errorf("PatchSubscriberByID err: gpsi does not exists")
 		c.JSON(http.StatusNotFound, gin.H{
 			"cause": "gpsi does not exists",
@@ -1582,6 +1822,12 @@ func PatchSubscriberByID(c *gin.Context) {
 	}
 	filterUeIdOnly := bson.M{"ueId": supi}
 	filter := bson.M{"ueId": supi, "servingPlmnId": servingPlmnId}
+
+	amData, ok := requireSubscriberAccess(c, supi, servingPlmnId)
+	if !ok {
+		return
+	}
+	tenantId, _ := subscriberTenantID(amData)
 
 	webAuthSubsBsonM := toBsonM(subsData.WebAuthenticationSubscription)
 	webAuthSubsBsonM["ueId"] = supi
@@ -1592,10 +1838,17 @@ func PatchSubscriberByID(c *gin.Context) {
 	}
 	authSubsBsonM := toBsonM(authSubs)
 	authSubsBsonM["ueId"] = ueId
+	if tenantId != "" {
+		webAuthSubsBsonM["tenantId"] = tenantId
+		authSubsBsonM["tenantId"] = tenantId
+	}
 
 	amDataBsonM := toBsonM(subsData.AccessAndMobilitySubscriptionData)
 	amDataBsonM["ueId"] = supi
 	amDataBsonM["servingPlmnId"] = servingPlmnId
+	if tenantId != "" {
+		amDataBsonM["tenantId"] = tenantId
+	}
 
 	// Replace all data with new one
 	if err := mongoapi.RestfulAPIDeleteMany(smDataColl, filter); err != nil {
@@ -1677,6 +1930,16 @@ func removeCdrFile(cdrFilePath string) {
 func DeleteSubscriberByID(c *gin.Context) {
 	setCorsHeader(c)
 	logger.ProcLog.Infoln("Delete One Subscriber Data")
+
+	claims, err := getAuthenticatedClaims(c)
+	if err != nil {
+		logger.ProcLog.Errorln(err.Error())
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"cause": "Illegal Token (Relogin required)!",
+		})
+		return
+	}
+
 	ueId := c.Param("ueId")
 	supi := gpsiToSupi(ueId)
 	servingPlmnId := c.Param("servingPlmnId")
@@ -1688,7 +1951,11 @@ func DeleteSubscriberByID(c *gin.Context) {
 		})
 		return
 	}
-	var claims jwt.MapClaims = nil
+
+	if _, ok := requireSubscriberAccess(c, supi, servingPlmnId); !ok {
+		return
+	}
+
 	dbOperation(supi, servingPlmnId, "delete", nil, nil, claims, false)
 
 	CdrFilePath := "/tmp/webconsole/"
@@ -1701,6 +1968,16 @@ func DeleteSubscriberByID(c *gin.Context) {
 func DeleteMultipleSubscribers(c *gin.Context) {
 	setCorsHeader(c)
 	logger.ProcLog.Infoln("Delete Multiple Subscribers")
+
+	claims, err := getAuthenticatedClaims(c)
+	if err != nil {
+		logger.ProcLog.Errorln(err.Error())
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"cause": "Illegal Token (Relogin required)!",
+		})
+		return
+	}
+
 	var subsDatas []*SubsListIE
 	if err := c.ShouldBindJSON(&subsDatas); err != nil {
 		logger.ProcLog.Errorf("DeleteMultipleSubscribers err: %+v", err)
@@ -1709,8 +1986,22 @@ func DeleteMultipleSubscribers(c *gin.Context) {
 		})
 		return
 	}
+	if len(subsDatas) == 0 {
+		c.Status(http.StatusNoContent)
+		return
+	}
 
-	var claims jwt.MapClaims = nil
+	for _, subsData := range subsDatas {
+		if subsData == nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"cause": "JSON format incorrect",
+			})
+			return
+		}
+		if _, ok := requireSubscriberAccess(c, subsData.UeId, subsData.PlmnID); !ok {
+			return
+		}
+	}
 
 	dbOperation("", "", "delete", nil, subsDatas, claims, true)
 

--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -1751,8 +1751,8 @@ func PutSubscriberByID(c *gin.Context) {
 	}
 
 	var subsData SubsData
-	if err := c.ShouldBindJSON(&subsData); err != nil {
-		logger.ProcLog.Errorf("PutSubscriberByID err: %v", err)
+	if bindErr := c.ShouldBindJSON(&subsData); bindErr != nil {
+		logger.ProcLog.Errorf("PutSubscriberByID err: %v", bindErr)
 		c.JSON(http.StatusBadRequest, gin.H{
 			"cause": "JSON format incorrect",
 		})
@@ -1979,8 +1979,8 @@ func DeleteMultipleSubscribers(c *gin.Context) {
 	}
 
 	var subsDatas []*SubsListIE
-	if err := c.ShouldBindJSON(&subsDatas); err != nil {
-		logger.ProcLog.Errorf("DeleteMultipleSubscribers err: %+v", err)
+	if bindErr := c.ShouldBindJSON(&subsDatas); bindErr != nil {
+		logger.ProcLog.Errorf("DeleteMultipleSubscribers err: %+v", bindErr)
 		c.JSON(http.StatusBadRequest, gin.H{
 			"cause": "JSON format incorrect",
 		})

--- a/backend/WebUI/routers.go
+++ b/backend/WebUI/routers.go
@@ -33,6 +33,7 @@ func NewRouter() *gin.Engine {
 
 func AddService(engine *gin.Engine) *gin.RouterGroup {
 	group := engine.Group("/api")
+	group.Use(AuthMiddleware())
 
 	for _, route := range routes {
 		switch route.Method {


### PR DESCRIPTION
### **fix(webconsole): require auth for subscriber APIs to prevent unauthenticated access (#1069)**

-   This PR fixes issue #1069 in WebConsole subscriber management.
    It prevents unauthenticated users from reading, modifying, or deleting subscriber records via subscriber APIs.

-   Root cause: the /api route group did not have a global authentication middleware, and several subscriber handlers relied on per-handler checks that were missing or incomplete.

-   Changes: Add JWT authentication middleware to the /api route group.
    Allow unauthenticated POST /api/login and OPTIONS preflight requests.
    Store parsed JWT claims, tenant ID, and admin status in Gin context.
    Enforce tenant ownership before subscriber GET/PUT/PATCH/DELETE operations.
    Stop using nil JWT claims when updating or deleting subscriber records.

- This is reported in [GitHub Issue #1069](https://github.com/free5gc/free5gc/issues/1069).