### PR TITLE
fix: validate DNN static IP before subscriber writes

### DIFF
--- a/backend/WebUI/api_verify.go
+++ b/backend/WebUI/api_verify.go
@@ -28,7 +28,10 @@ type VerifyScope struct {
 
 var errInvalidStaticIP = errors.New("invalid static IPv4 address")
 
-const responseCause = "cause"
+const (
+	responseCause      = "cause"
+	singleNssaiSDField = "singleNssai.sd"
+)
 
 type staticIPPoolProvider func(models.Snssai, string) ([]netip.Prefix, error)
 
@@ -412,11 +415,11 @@ func buildStaticIPCollisionFilter(checkData VerifyScope) bson.M {
 		"ueId":            bson.D{{Key: "$ne", Value: checkData.Supi}}, // not this UE
 	}
 	if checkData.Sd != "" {
-		filter["singleNssai.sd"] = checkData.Sd
+		filter[singleNssaiSDField] = checkData.Sd
 	} else {
 		filter["$or"] = bson.A{
-			bson.M{"singleNssai.sd": bson.M{"$exists": false}},
-			bson.M{"singleNssai.sd": ""},
+			bson.M{singleNssaiSDField: bson.M{"$exists": false}},
+			bson.M{singleNssaiSDField: ""},
 		}
 	}
 	return filter

--- a/backend/WebUI/api_verify.go
+++ b/backend/WebUI/api_verify.go
@@ -369,18 +369,8 @@ func checkIpCollisionFromDb(
 	c *gin.Context,
 	checkData VerifyScope,
 ) error {
-	snssai := models.Snssai{
-		Sst: int32(checkData.Sst),
-	}
-	if checkData.Sd != "" {
-		snssai.Sd = checkData.Sd
-	}
-
 	smDataColl := "subscriptionData.provisionedData.smData"
-	filter := bson.M{
-		"singleNssai": snssai,
-		"ueId":        bson.D{{Key: "$ne", Value: checkData.Supi}}, // not this UE
-	}
+	filter := buildStaticIPCollisionFilter(checkData)
 	smDataDataInterface, mongo_err := mongoapi.RestfulAPIGetMany(smDataColl, filter)
 	if mongo_err != nil {
 		logger.ProcLog.Warningln(smDataColl, "mongo error: ", mongo_err)
@@ -414,4 +404,20 @@ func checkIpCollisionFromDb(
 		}
 	}
 	return nil
+}
+
+func buildStaticIPCollisionFilter(checkData VerifyScope) bson.M {
+	filter := bson.M{
+		"singleNssai.sst": int32(checkData.Sst),
+		"ueId":            bson.D{{Key: "$ne", Value: checkData.Supi}}, // not this UE
+	}
+	if checkData.Sd != "" {
+		filter["singleNssai.sd"] = checkData.Sd
+	} else {
+		filter["$or"] = bson.A{
+			bson.M{"singleNssai.sd": bson.M{"$exists": false}},
+			bson.M{"singleNssai.sd": ""},
+		}
+	}
+	return filter
 }

--- a/backend/WebUI/api_verify.go
+++ b/backend/WebUI/api_verify.go
@@ -2,9 +2,11 @@ package WebUI
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/netip"
+	"sort"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson"
@@ -24,6 +26,17 @@ type VerifyScope struct {
 	Ipaddr string `json:"ipaddr"`
 }
 
+var errInvalidStaticIP = errors.New("invalid static IPv4 address")
+
+const responseCause = "cause"
+
+type staticIPPoolProvider func(models.Snssai, string) ([]netip.Prefix, error)
+
+type staticIPPoolCacheKey struct {
+	snssai models.Snssai
+	dnn    string
+}
+
 func GetSmfUserPlaneInfo() (interface{}, error) {
 	logger.ProcLog.Infoln("Get SMF UserPlane Info")
 
@@ -33,7 +46,7 @@ func GetSmfUserPlaneInfo() (interface{}, error) {
 	var jsonData interface{}
 
 	// TODO: support fetching data from multiple SMF
-	if smfUris := webuiSelf.GetOamUris(models.NrfNfManagementNfType_SMF); smfUris != nil {
+	if smfUris := webuiSelf.GetOamUris(models.NrfNfManagementNfType_SMF); len(smfUris) > 0 {
 		requestUri := fmt.Sprintf("%s/nsmf-oam/v1/user-plane-info/", smfUris[0])
 
 		ctx, pd, err := webuiSelf.GetTokenCtx(models.ServiceName_NSMF_OAM, models.NrfNfManagementNfType_SMF)
@@ -64,15 +77,20 @@ func GetSmfUserPlaneInfo() (interface{}, error) {
 			}
 		}()
 
-		json_err := json.NewDecoder(resp.Body).Decode(&jsonData)
-		if json_err != nil {
-			logger.ProcLog.Errorf("Decode Json err: %+v", err)
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return nil, fmt.Errorf("SMF user-plane info request returned status %s", resp.Status)
 		}
-		return jsonData, err
-	} else {
-		logger.ProcLog.Error("No SMF Found")
+
+		if decodeErr := json.NewDecoder(resp.Body).Decode(&jsonData); decodeErr != nil {
+			logger.ProcLog.Errorf("Decode Json err: %+v", decodeErr)
+			return nil, decodeErr
+		}
+		return jsonData, nil
 	}
-	return jsonData, nil
+
+	err := errors.New("no SMF found")
+	logger.ProcLog.Error(err)
+	return nil, err
 }
 
 func GetStaticIpPoolsFromUserPlaneInfomation(
@@ -80,39 +98,54 @@ func GetStaticIpPoolsFromUserPlaneInfomation(
 	snssai models.Snssai,
 	dnn string,
 ) ([]netip.Prefix, error) {
-	result := []netip.Prefix{}
+	poolSet := make(map[netip.Prefix]struct{})
 
-	for nodeName := range userplaneinfo.UPNodes {
-		if userplaneinfo.UPNodes[nodeName].Type == "UPF" {
+	for _, node := range userplaneinfo.UPNodes {
+		if node != nil && node.Type == "UPF" {
 			// Find the UPF node
-			for _, snssaiupfinfo := range userplaneinfo.UPNodes[nodeName].SNssaiInfos {
+			for _, snssaiupfinfo := range node.SNssaiInfos {
 				// Find the Slice (snssai)
-				if *snssaiupfinfo.SNssai == snssai {
+				if snssaiupfinfo != nil &&
+					snssaiupfinfo.SNssai != nil &&
+					*snssaiupfinfo.SNssai == snssai {
 					for _, dnnInfo := range snssaiupfinfo.DnnUpfInfoList {
 						// Find the DNN name
-						if dnnInfo.Dnn == dnn {
-							if len(dnnInfo.StaticPools) > 0 {
-								for _, pool := range dnnInfo.StaticPools {
-									staticPoolstr := pool.Cidr
-									net, parseErr := netip.ParsePrefix(staticPoolstr)
-									if parseErr != nil {
-										return result, parseErr
-									}
-									result = append(result, net)
+						if dnnInfo != nil && dnnInfo.Dnn == dnn {
+							for _, pool := range dnnInfo.StaticPools {
+								if pool == nil {
+									return nil, fmt.Errorf(
+										"nil static IP pool for S-NSSAI %+v and DNN %q",
+										snssai,
+										dnn,
+									)
 								}
-								return result, nil
+								prefix, parseErr := netip.ParsePrefix(pool.Cidr)
+								if parseErr != nil {
+									return nil, fmt.Errorf(
+										"parse static IP pool %q for S-NSSAI %+v and DNN %q: %w",
+										pool.Cidr,
+										snssai,
+										dnn,
+										parseErr,
+									)
+								}
+								poolSet[prefix.Masked()] = struct{}{}
 							}
-							// If there is no static pool, return smallest
-							net, parseErr := netip.ParsePrefix("0.0.0.0/32")
-							return []netip.Prefix{net}, parseErr
 						}
 					}
 				}
 			}
 		}
 	}
-	net, parseErr := netip.ParsePrefix("0.0.0.0/32")
-	return []netip.Prefix{net}, parseErr
+
+	result := make([]netip.Prefix, 0, len(poolSet))
+	for pool := range poolSet {
+		result = append(result, pool)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].String() < result[j].String()
+	})
+	return result, nil
 }
 
 func getDnnStaticIpPools(snssai models.Snssai, dnn string) ([]netip.Prefix, error) {
@@ -127,14 +160,132 @@ func getDnnStaticIpPools(snssai models.Snssai, dnn string) ([]netip.Prefix, erro
 	tmp, err := json.Marshal(raw_info)
 	if err != nil {
 		logger.ProcLog.Errorf("Marshal err: %+v", err)
+		return nil, err
 	}
-	unmarshal_err := json.Unmarshal(tmp, &userplaneinfo)
-	if unmarshal_err != nil {
-		logger.ProcLog.Errorf("Unmarshal err: %+v", unmarshal_err)
-		return []netip.Prefix{}, unmarshal_err
+	if unmarshalErr := json.Unmarshal(tmp, &userplaneinfo); unmarshalErr != nil {
+		logger.ProcLog.Errorf("Unmarshal err: %+v", unmarshalErr)
+		return nil, unmarshalErr
 	}
 
 	return GetStaticIpPoolsFromUserPlaneInfomation(&userplaneinfo, snssai, dnn)
+}
+
+func validateStaticIPv4InPools(address string, staticPools []netip.Prefix) error {
+	staticIP, err := netip.ParseAddr(address)
+	if err != nil {
+		return fmt.Errorf("%w %q: %v", errInvalidStaticIP, address, err)
+	}
+	if !staticIP.Is4() {
+		return fmt.Errorf("%w %q: address is not IPv4", errInvalidStaticIP, address)
+	}
+	if len(staticPools) == 0 {
+		return fmt.Errorf("%w %q: no static IP pool is configured", errInvalidStaticIP, address)
+	}
+
+	for _, staticPool := range staticPools {
+		if staticPool.Contains(staticIP) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w %q: address is not in any static IP pool", errInvalidStaticIP, address)
+}
+
+func validateSubscriberStaticIPs(
+	smData []models.SessionManagementSubscriptionData,
+	poolProvider staticIPPoolProvider,
+) error {
+	poolCache := make(map[staticIPPoolCacheKey][]netip.Prefix)
+
+	for _, sessionData := range smData {
+		for dnn, dnnConfig := range sessionData.DnnConfigurations {
+			if len(dnnConfig.StaticIpAddress) == 0 {
+				continue
+			}
+			if sessionData.SingleNssai == nil {
+				return fmt.Errorf(
+					"%w for DNN %q: S-NSSAI is required",
+					errInvalidStaticIP,
+					dnn,
+				)
+			}
+
+			key := staticIPPoolCacheKey{
+				snssai: *sessionData.SingleNssai,
+				dnn:    dnn,
+			}
+			for _, staticAddress := range dnnConfig.StaticIpAddress {
+				if staticAddress.Ipv4Addr == "" {
+					return fmt.Errorf(
+						"%w for S-NSSAI %+v and DNN %q: IPv4 address is required",
+						errInvalidStaticIP,
+						key.snssai,
+						dnn,
+					)
+				}
+				if _, parseErr := netip.ParseAddr(staticAddress.Ipv4Addr); parseErr != nil {
+					return fmt.Errorf(
+						"%w for S-NSSAI %+v and DNN %q: %v",
+						errInvalidStaticIP,
+						key.snssai,
+						dnn,
+						parseErr,
+					)
+				}
+
+				staticPools, ok := poolCache[key]
+				if !ok {
+					var getErr error
+					staticPools, getErr = poolProvider(key.snssai, dnn)
+					if getErr != nil {
+						return fmt.Errorf(
+							"get static IP pools for S-NSSAI %+v and DNN %q: %w",
+							key.snssai,
+							dnn,
+							getErr,
+						)
+					}
+					poolCache[key] = staticPools
+				}
+
+				if validationErr := validateStaticIPv4InPools(
+					staticAddress.Ipv4Addr,
+					staticPools,
+				); validationErr != nil {
+					return fmt.Errorf(
+						"%w for S-NSSAI %+v and DNN %q",
+						validationErr,
+						key.snssai,
+						dnn,
+					)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateSubscriberStaticIPsForWrite(
+	c *gin.Context,
+	subsData *SubsData,
+	poolProvider staticIPPoolProvider,
+) bool {
+	err := validateSubscriberStaticIPs(
+		subsData.SessionManagementSubscriptionData,
+		poolProvider,
+	)
+	if err == nil {
+		return true
+	}
+
+	status := http.StatusInternalServerError
+	if errors.Is(err, errInvalidStaticIP) {
+		status = http.StatusBadRequest
+	}
+	logger.ProcLog.Warnf("Static IP validation failed: %v", err)
+	c.JSON(status, gin.H{responseCause: err.Error()})
+	return false
 }
 
 func VerifyStaticIP(c *gin.Context) {
@@ -181,32 +332,23 @@ func VerifyStaticIpProcedure(
 	checkData VerifyScope,
 	staticPools []netip.Prefix,
 ) {
-	staticIp, parse_err := netip.ParseAddr(checkData.Ipaddr)
-	if parse_err != nil {
-		logger.ProcLog.Errorln(parse_err.Error())
+	if validationErr := validateStaticIPv4InPools(checkData.Ipaddr, staticPools); validationErr != nil {
 		c.JSON(http.StatusOK, gin.H{
-			"valid": false,
-			"cause": parse_err.Error(),
+			"ipaddr": checkData.Ipaddr,
+			"valid":  false,
+			"cause":  validationErr.Error(),
 		})
+		logger.ProcLog.Debugln("StaticIP validation failed:", validationErr)
 		return
 	}
-	logger.ProcLog.Debugln("check IP address:", staticIp)
-
-	// Check in Static Pool
-	result := false
-	for _, staticPool := range staticPools {
-		result = staticPool.Contains(staticIp)
-		if result {
-			break
-		}
-	}
-	if !result {
+	staticIP, parseErr := netip.ParseAddr(checkData.Ipaddr)
+	if parseErr != nil {
 		c.JSON(http.StatusOK, gin.H{
-			"ipaddr": staticIp,
-			"valid":  result,
-			"cause":  "Not in static pools!",
+			"ipaddr": checkData.Ipaddr,
+			"valid":  false,
+			"cause":  parseErr.Error(),
 		})
-		logger.ProcLog.Debugln("StaticIP", staticIp, ": not in static pool!")
+		logger.ProcLog.Debugln("StaticIP", staticIP, ": not in static pool!")
 		return
 	}
 
@@ -216,8 +358,8 @@ func VerifyStaticIpProcedure(
 
 	// Return the result
 	c.JSON(http.StatusOK, gin.H{
-		"ipaddr": staticIp,
-		"valid":  result,
+		"ipaddr": staticIP,
+		"valid":  true,
 		"cause":  "",
 	})
 }

--- a/backend/WebUI/api_verify_test.go
+++ b/backend/WebUI/api_verify_test.go
@@ -22,6 +22,7 @@ func TestGetStaticIpPoolsFromUserPlaneInfomation(t *testing.T) {
 		Dnn           string
 		Userplaneinfo smf_factory.UserPlaneInformation
 		ExpectIpPools []string
+		ExpectError   bool
 	}{
 		{
 			Name: "Simple",
@@ -156,6 +157,131 @@ func TestGetStaticIpPoolsFromUserPlaneInfomation(t *testing.T) {
 				"10.60.101.0/24",
 			},
 		},
+		{
+			Name: "Pools from multiple matching UPFs",
+			Snssai: models.Snssai{
+				Sst: 1,
+				Sd:  "010203",
+			},
+			Dnn: "internet",
+			Userplaneinfo: smf_factory.UserPlaneInformation{
+				UPNodes: map[string]*smf_factory.UPNode{
+					"UPF1": {
+						Type: "UPF",
+						SNssaiInfos: []*smf_factory.SnssaiUpfInfoItem{
+							{
+								SNssai: &models.Snssai{Sst: 1, Sd: "010203"},
+								DnnUpfInfoList: []*smf_factory.DnnUpfInfoItem{
+									{
+										Dnn: "internet",
+										StaticPools: []*smf_factory.UEIPPool{
+											{Cidr: "10.60.100.0/24"},
+										},
+									},
+								},
+							},
+						},
+					},
+					"UPF2": {
+						Type: "UPF",
+						SNssaiInfos: []*smf_factory.SnssaiUpfInfoItem{
+							{
+								SNssai: &models.Snssai{Sst: 1, Sd: "010203"},
+								DnnUpfInfoList: []*smf_factory.DnnUpfInfoItem{
+									{
+										Dnn: "internet",
+										StaticPools: []*smf_factory.UEIPPool{
+											{Cidr: "10.60.101.0/24"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectIpPools: []string{
+				"10.60.100.0/24",
+				"10.60.101.0/24",
+			},
+		},
+		{
+			Name: "DNN not found",
+			Snssai: models.Snssai{
+				Sst: 1,
+				Sd:  "010203",
+			},
+			Dnn: "internet",
+			Userplaneinfo: smf_factory.UserPlaneInformation{
+				UPNodes: map[string]*smf_factory.UPNode{
+					"UPF": {
+						Type: "UPF",
+						SNssaiInfos: []*smf_factory.SnssaiUpfInfoItem{
+							{
+								SNssai: &models.Snssai{Sst: 1, Sd: "010203"},
+								DnnUpfInfoList: []*smf_factory.DnnUpfInfoItem{
+									{Dnn: "ims"},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectIpPools: []string{},
+		},
+		{
+			Name: "DNN has no static pools",
+			Snssai: models.Snssai{
+				Sst: 1,
+				Sd:  "010203",
+			},
+			Dnn: "internet",
+			Userplaneinfo: smf_factory.UserPlaneInformation{
+				UPNodes: map[string]*smf_factory.UPNode{
+					"UPF": {
+						Type: "UPF",
+						SNssaiInfos: []*smf_factory.SnssaiUpfInfoItem{
+							{
+								SNssai: &models.Snssai{Sst: 1, Sd: "010203"},
+								DnnUpfInfoList: []*smf_factory.DnnUpfInfoItem{
+									{Dnn: "internet"},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectIpPools: []string{},
+		},
+		{
+			Name: "Malformed static pool CIDR",
+			Snssai: models.Snssai{
+				Sst: 1,
+				Sd:  "010203",
+			},
+			Dnn: "internet",
+			Userplaneinfo: smf_factory.UserPlaneInformation{
+				UPNodes: map[string]*smf_factory.UPNode{
+					"UPF": {
+						Type: "UPF",
+						SNssaiInfos: []*smf_factory.SnssaiUpfInfoItem{
+							{
+								SNssai: &models.Snssai{Sst: 1, Sd: "010203"},
+								DnnUpfInfoList: []*smf_factory.DnnUpfInfoItem{
+									{
+										Dnn: "internet",
+										StaticPools: []*smf_factory.UEIPPool{
+											{Cidr: "not-a-cidr"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectError: true,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -168,6 +294,10 @@ func TestGetStaticIpPoolsFromUserPlaneInfomation(t *testing.T) {
 		}
 
 		resultPools, err := WebUI.GetStaticIpPoolsFromUserPlaneInfomation(&tc.Userplaneinfo, tc.Snssai, tc.Dnn)
+		if tc.ExpectError {
+			require.Error(t, err)
+			continue
+		}
 		require.NoError(t, err)
 
 		require.Equal(t, pools, resultPools)

--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -1835,6 +1835,9 @@ func PatchSubscriberByID(c *gin.Context) {
 	if !ok {
 		return
 	}
+	if !validateSubscriberStaticIPsForWrite(c, &subsData, getDnnStaticIpPools) {
+		return
+	}
 	tenantId, _ := subscriberTenantID(amData)
 
 	webAuthSubsBsonM := toBsonM(subsData.WebAuthenticationSubscription)
@@ -1845,7 +1848,7 @@ func PatchSubscriberByID(c *gin.Context) {
 		logger.ProcLog.Errorf("WebAuthSubToModels err: %+v", errModels)
 	}
 	authSubsBsonM := toBsonM(authSubs)
-	authSubsBsonM["ueId"] = ueId
+	authSubsBsonM["ueId"] = supi
 	if tenantId != "" {
 		webAuthSubsBsonM["tenantId"] = tenantId
 		authSubsBsonM["tenantId"] = tenantId
@@ -1858,18 +1861,22 @@ func PatchSubscriberByID(c *gin.Context) {
 		amDataBsonM["tenantId"] = tenantId
 	}
 
+	smDataBsonA := make([]interface{}, 0, len(subsData.SessionManagementSubscriptionData))
+	for _, data := range subsData.SessionManagementSubscriptionData {
+		smDataBsonM := toBsonM(data)
+		smDataBsonM["ueId"] = supi
+		smDataBsonM["servingPlmnId"] = servingPlmnId
+		smDataBsonA = append(smDataBsonA, smDataBsonM)
+	}
+
 	// Replace all data with new one
 	if err := mongoapi.RestfulAPIDeleteMany(smDataColl, filter); err != nil {
 		logger.ProcLog.Errorf("PatchSubscriberByID err: %+v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{})
 		return
 	}
-	for _, data := range subsData.SessionManagementSubscriptionData {
-		smDataBsonM := toBsonM(data)
-		smDataBsonM["ueId"] = supi
-		smDataBsonM["servingPlmnId"] = servingPlmnId
-		filterSmData := bson.M{"ueId": supi, "servingPlmnId": servingPlmnId, "snssai": data.SingleNssai}
-		if err := mongoapi.RestfulAPIMergePatch(smDataColl, filterSmData, smDataBsonM); err != nil {
+	if len(smDataBsonA) > 0 {
+		if err := mongoapi.RestfulAPIPostMany(smDataColl, filter, smDataBsonA); err != nil {
 			logger.ProcLog.Errorf("PatchSubscriberByID err: %+v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{})
 			return

--- a/backend/WebUI/api_webui.go
+++ b/backend/WebUI/api_webui.go
@@ -1333,6 +1333,10 @@ func PostSubscriberByID(c *gin.Context) {
 		return
 	}
 
+	if !validateSubscriberStaticIPsForWrite(c, &subsData, getDnnStaticIpPools) {
+		return
+	}
+
 	for i := 0; i < userNumberTemp; i++ {
 		ueId = fmt.Sprintf("imsi-%015d", ueIdTemp)
 		if gpsiInt != 0 {
@@ -1768,6 +1772,10 @@ func PutSubscriberByID(c *gin.Context) {
 	if exists {
 		tenantId, _ := subscriberTenantID(amData)
 		writeClaims = claimsWithTenant(claims, tenantId)
+	}
+
+	if !validateSubscriberStaticIPsForWrite(c, &subsData, getDnnStaticIpPools) {
+		return
 	}
 
 	// modify a gpsi-supi map

--- a/frontend/src/pages/SubscriberCreate/SubscriberFormSessions.tsx
+++ b/frontend/src/pages/SubscriberCreate/SubscriberFormSessions.tsx
@@ -35,9 +35,15 @@ interface VerifyResult {
   cause: string;
 }
 
-const handleVerifyStaticIp = (sd: string, sst: number, dnn: string, ipaddr: string) => {
+const handleVerifyStaticIp = (
+  supi: string,
+  sd: string,
+  sst: number,
+  dnn: string,
+  ipaddr: string,
+) => {
   const scope: VerifyScope = {
-    supi: "",
+    supi: supi,
     sd: sd,
     sst: sst,
     dnn: dnn,
@@ -300,6 +306,7 @@ export default function SubscriberFormSessions() {
                               variant="contained"
                               onClick={() =>
                                 handleVerifyStaticIp(
+                                  watch("ueId"),
                                   row.sd,
                                   row.sst,
                                   dnn,


### PR DESCRIPTION
### **fix(webconsole): validate DNN static IP before subscriber writes (#720)**

- This PR fixes issue #720 in WebConsole subscriber management.
  It prevents invalid Static IPv4 addresses from being saved when creating or updating subscribers.

- Root cause: 
  - Static IP validation was only performed through the optional `/verify-staticip` request.
  - Subscriber Create and Update APIs did not enforce the same validation before writing subscription data, allowing addresses outside the configured DNN Static IP Pool to be stored.

- Changes:
  - Reuse Static IPv4 validation across Verify and Subscriber Create/Update APIs.
  - Aggregate and cache matching UPF pools; skip pool lookup when no Static IP is configured.
  - Return `400` for invalid addresses and `500` for SMF or pool configuration errors.
  - Pass the current SUPI to avoid self-collision during verification.
  - Extend `api_verify_test.go` to cover pool aggregation and address validation.

- This is reported in [GitHub Issue #720](https://github.com/free5gc/free5gc/issues/720).